### PR TITLE
Fix benchmarks

### DIFF
--- a/core.go
+++ b/core.go
@@ -184,7 +184,7 @@ func (s *Store) Close() error {
 
 // Delete provided storage
 func (s *Store) Delete() error {
-	err := s.Close()
+	err := s.data.Close()
 	if err == nil {
 		indexFileName := fmt.Sprintf("%s.idx", s.name)
 		err = os.Remove(indexFileName)

--- a/core_test.go
+++ b/core_test.go
@@ -40,14 +40,29 @@ func TestOpen(t *testing.T) {
 	s.Close()
 }
 
-// BenchmarkOpen for an iterative improvement
+// BenchmarkOpen for iterative improvement of open
 func BenchmarkOpen(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		b.StartTimer()
+		s, err := beansdb.Open("testdata/words")
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StopTimer()
+		s.Close()
+	}
+}
+
+// BenchmarkClose for iterative improvement of close
+func BenchmarkClose(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		s, err := beansdb.Open("testdata/words")
 		if err != nil {
 			b.Fatal(err)
 		}
+		b.StartTimer()
 		s.Close()
+		b.StopTimer()
 	}
 }
 
@@ -87,13 +102,12 @@ func TestWrite(t *testing.T) {
 	}
 }
 
-// BenchmarkWrite for an iterative improvement
+// BenchmarkWrite for iterative improvement or writes
 func BenchmarkWrite(b *testing.B) {
 	s, err := beansdb.New()
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer s.Delete()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
@@ -107,6 +121,9 @@ func BenchmarkWrite(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+	b.StopTimer()
+	s.Delete()
+
 }
 
 // TestRead to ensure we can read from the store
@@ -128,13 +145,12 @@ func TestRead(t *testing.T) {
 	}
 }
 
-// BenchmarkRead for an iterative improvement
+// BenchmarkRead for iterative improvement of reads
 func BenchmarkRead(b *testing.B) {
 	s, err := beansdb.Open("testdata/words")
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer s.Close()
 	score := s.MakeScore([]byte("witchwork"))
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -143,6 +159,8 @@ func BenchmarkRead(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+	b.StopTimer()
+	s.Close()
 }
 
 // TestWriteRead to ensure we can read back written


### PR DESCRIPTION
```
go test -bench=. -benchmem
goos: darwin
goarch: amd64
pkg: github.com/eiri/beansdb
BenchmarkOpen-4                3         467322486 ns/op        107339632 B/op    943836 allocs/op
BenchmarkWrite-4           10000            122795 ns/op            1518 B/op          3 allocs/op
BenchmarkRead-4           500000              2988 ns/op             132 B/op          1 allocs/op
PASS
```

vs

```
go test -bench=. -benchmem
goos: darwin
goarch: amd64
pkg: github.com/eiri/beansdb
BenchmarkOpen-4                5         252199241 ns/op        48930233 B/op     471996 allocs/op
BenchmarkClose-4               3         341262235 ns/op        74719498 B/op     629168 allocs/op
BenchmarkWrite-4           10000            131734 ns/op            1281 B/op          1 allocs/op
BenchmarkRead-4           500000              2465 ns/op              16 B/op          1 allocs/op
PASS
```