### PR TITLE
Write index along the data writes instead of a dump on a close

### DIFF
--- a/core_test.go
+++ b/core_test.go
@@ -43,26 +43,11 @@ func TestOpen(t *testing.T) {
 // BenchmarkOpen for iterative improvement of open
 func BenchmarkOpen(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		b.StartTimer()
 		s, err := beansdb.Open("testdata/words")
 		if err != nil {
 			b.Fatal(err)
 		}
-		b.StopTimer()
 		s.Close()
-	}
-}
-
-// BenchmarkClose for iterative improvement of close
-func BenchmarkClose(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		s, err := beansdb.Open("testdata/words")
-		if err != nil {
-			b.Fatal(err)
-		}
-		b.StartTimer()
-		s.Close()
-		b.StopTimer()
 	}
 }
 


### PR DESCRIPTION
Bench (note open now _includes_ close as well)
```
$ benchcmp before.bench after.bench
ignoring BenchmarkClose-4: before has 1 instances, after has 0
benchmark            old ns/op     new ns/op     delta
BenchmarkOpen-4      527945589     532161378     +0.80%
BenchmarkWrite-4     163255        121155        -25.79%
BenchmarkRead-4      2243          2122          -5.39%

benchmark            old allocs     new allocs     delta
BenchmarkOpen-4      9629           9634           +0.05%
BenchmarkWrite-4     1              2              +100.00%
BenchmarkRead-4      1              1              +0.00%

benchmark            old bytes     new bytes     delta
BenchmarkOpen-4      41070596      41062484      -0.02%
BenchmarkWrite-4     1280          1313          +2.58%
BenchmarkRead-4      16            16            +0.00%
```