### PR TITLE
Compare sizes and bench of md5 vs sha1 score

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 *.dylib
 *.tgz
 *.zip
+index-sizes
+!cmd/index-sizes/
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ clean: clean-data ## clean up
 	rm -f *.bench
 	rm -f testdata/*.data
 	rm -f testdata/*.idx
-	rm -f testdata/*.golden
+	rm -f index-sizes
 
 .PHONY: clean-data
 clean-data: ## remove index and datalog files from the test runs
@@ -47,3 +47,8 @@ clean-data: ## remove index and datalog files from the test runs
 .PHONY: format
 format: ## format code
 	go fmt -x *.go
+
+.PHONY: index-sizes
+index-sizes: ## compare index sizes
+	@go build -o index-sizes $(CURDIR)/cmd/index-sizes/main.go
+	@$(CURDIR)/index-sizes

--- a/cmd/index-sizes/main.go
+++ b/cmd/index-sizes/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/binary"
+	"encoding/hex"
+	"log"
+	"math/big"
+	"os"
+)
+
+type hashingFunc func() []byte
+
+var md5Hmac = hmac.New(md5.New, []byte("secret"))
+var sha1Hmac = hmac.New(sha1.New, []byte("secret"))
+
+func makeSize() uint32 {
+	size, _ := rand.Int(rand.Reader, big.NewInt(big.MaxPrec))
+	return uint32(size.Uint64())
+}
+
+func MakeMd5Score() []byte {
+	data := make([]byte, 65536)
+	rand.Read(data)
+	md5Hmac.Reset()
+	md5Hmac.Write(data)
+	score := md5Hmac.Sum(nil)
+	return score[:]
+}
+
+func MakeSha1Score() []byte {
+	data := make([]byte, 65536)
+	rand.Read(data)
+	sha1Hmac.Reset()
+	sha1Hmac.Write(data)
+	score := sha1Hmac.Sum(nil)
+	return score[:]
+}
+
+func makeIdx(name string, num int, hf hashingFunc) int64 {
+	f, err := os.Create(name)
+	if err != nil {
+		log.Panic(err)
+	}
+	defer f.Close()
+	for i := 1; i <= num; i++ {
+		size := makeSize()
+		score := hf()
+		//log.Printf("score %x, size %d", score, size)
+		buf := make([]byte, 4)
+		binary.BigEndian.PutUint32(buf, size)
+		buf = append(buf, score...)
+		_, err := f.Write(buf)
+		if err != nil {
+			log.Panic(err)
+		}
+	}
+	stat, _ := f.Stat()
+	return stat.Size()
+}
+
+func main() {
+	buf := make([]byte, 16)
+	rand.Read(buf)
+	baseName := hex.EncodeToString(buf)
+	keyNum := 10000
+	name := baseName + "-md5.idx"
+	size := makeIdx(name, keyNum, MakeMd5Score)
+	log.Printf("Hashing  md5, %d keys, filesize: %d", keyNum, size)
+
+	name = baseName + "-sha1.idx"
+	size = makeIdx(name, keyNum, MakeSha1Score)
+	log.Printf("Hashing sha1, %d keys, filesize: %d", keyNum, size)
+}

--- a/cmd/index-sizes/main_test.go
+++ b/cmd/index-sizes/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexSizesHashingFuncs(t *testing.T) {
+	assert := require.New(t)
+
+	t.Run("md5", func(t *testing.T) {
+		score1 := MakeMd5Score()
+		assert.Len(score1, 16)
+		score2 := MakeMd5Score()
+		assert.NotEqual(score1, score2)
+	})
+
+	t.Run("sha1", func(t *testing.T) {
+		score1 := MakeSha1Score()
+		assert.Len(score1, 20)
+		score2 := MakeSha1Score()
+		assert.NotEqual(score1, score2)
+	})
+}
+
+func BenchmarkMd5(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		MakeMd5Score()
+	}
+}
+
+func BenchmarkSha1(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		MakeSha1Score()
+	}
+}


### PR DESCRIPTION
I guess `hmac-md5` is the way to go
```bash
$ make index-sizes 
2019/03/02 22:38:49 Hashing  md5, 10000 keys, filesize: 200000
2019/03/02 22:39:12 Hashing sha1, 10000 keys, filesize: 240000
```

```bash
$ du -h f2122ae70795339b6a83979e0453f8f1*
196K    f2122ae70795339b6a83979e0453f8f1-md5.idx
260K    f2122ae70795339b6a83979e0453f8f1-sha1.idx
```

```bash
$ go test -bench=. -benchmem cmd/index-sizes/*.go
goos: darwin
goarch: amd64
BenchmarkMd5-4          1000       2165790 ns/op       65552 B/op          2 allocs/op
BenchmarkSha1-4         1000       2134386 ns/op       65568 B/op          2 allocs/op
PASS
ok      command-line-arguments  4.757s
```

Closes #10 