### PR TITLE
Store score in datalog file too

### DIFF
--- a/api.go
+++ b/api.go
@@ -78,7 +78,7 @@ func (s *Store) Write(b []byte) (score Score, err error) {
 	if _, _, ok := s.index.Read(score); ok {
 		return
 	}
-	p, l, err := s.data.Write(b)
+	p, l, err := s.data.Write(score, b)
 	if err != nil {
 		return
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -132,7 +132,6 @@ func BenchmarkWrite(b *testing.B) {
 	}
 	b.StopTimer()
 	s.Delete()
-
 }
 
 // BenchmarkRead for iterative improvement of reads

--- a/datalog.go
+++ b/datalog.go
@@ -66,8 +66,6 @@ func (d *Datalog) Write(score Score, data []byte) (pos, size int, err error) {
 	size = len(data) + scoreSize
 	buf := make([]byte, intSize+size)
 	binary.BigEndian.PutUint32(buf, uint32(size))
-	// buf = append(buf, score[:]...)
-	// buf = append(buf, data...)
 	copy(buf[intSize:], score[:])
 	copy(buf[intSize+scoreSize:], data)
 	n, err := d.rwc.Write(buf)

--- a/datalog_test.go
+++ b/datalog_test.go
@@ -40,7 +40,8 @@ func TestDataLog(t *testing.T) {
 		expectedPos := intSize
 		for _, word := range strings.Fields(words) {
 			data := []byte(word)
-			pos, size, err := dl.Write(data)
+			score := MakeScore(data)
+			pos, size, err := dl.Write(score, data)
 			assert.NoError(err)
 			assert.Equal(expectedPos, pos, "Position should move")
 			assert.Equal(pos+size, dl.cur, "Cursor should move")
@@ -61,7 +62,7 @@ func TestDataLog(t *testing.T) {
 		for _, word := range strings.Fields(words) {
 			expectedData := []byte(word)
 			pos += intSize
-			size := len(expectedData)
+			size := len(expectedData) + scoreSize
 			data, err := dl.Read(pos, size)
 			assert.NoError(err)
 			assert.Equal(expectedData, data)

--- a/index.go
+++ b/index.go
@@ -123,17 +123,19 @@ func (idx *Index) Rebuild() error {
 			break
 		}
 		l := int(binary.BigEndian.Uint32(lBuf))
-		buf := make([]byte, l)
+		buf := make([]byte, scoreSize)
 		if _, err = f.Read(buf); err == io.EOF {
 			err = nil
 			break
 		}
-		score := MakeScore(buf)
+		var score Score
+		copy(score[:], buf)
 		err = idx.Write(score, p, l)
 		if err != nil {
 			break
 		}
 		p += l + intSize
+		f.Seek(int64(l-scoreSize), 1)
 	}
 	return err
 }

--- a/index_test.go
+++ b/index_test.go
@@ -123,9 +123,9 @@ func TestIndexRebuild(t *testing.T) {
 	expectedCache := make(cache)
 	for _, word := range strings.Fields(words) {
 		data := []byte(word)
-		pos, size, err := dl.Write(data)
-		assert.NoError(err)
 		score := MakeScore(data)
+		pos, size, err := dl.Write(score, data)
+		assert.NoError(err)
 		expectedCache[score] = addr{pos, size}
 	}
 	dl.Close()


### PR DESCRIPTION
Bit of optimization for index rebuild and preparation to moving of index management into datalog. No bench penalty, only disk one

```
benchmark                old ns/op     new ns/op     delta
BenchmarkIndexLoad-4     78380828      78160618      -0.28%
BenchmarkOpen-4          77846975      77664061      -0.23%
BenchmarkWrite-4         23334         23379         +0.19%
BenchmarkRead-4          3983          4030          +1.18%

benchmark                old allocs     new allocs     delta
BenchmarkIndexLoad-4     9623           9608           -0.16%
BenchmarkOpen-4          9635           9641           +0.06%
BenchmarkWrite-4         1              1              +0.00%
BenchmarkRead-4          1              1              +0.00%

benchmark                old bytes     new bytes     delta
BenchmarkIndexLoad-4     41072605      41071168      -0.00%
BenchmarkOpen-4          41074290      41078896      +0.01%
BenchmarkWrite-4         1259          1260          +0.08%
BenchmarkRead-4          16            16            +0.00%

```