### PR TITLE
Combine index load with index opening

### DIFF
--- a/datalog.go
+++ b/datalog.go
@@ -48,8 +48,7 @@ func (d *Datalog) Open() error {
 	if err != nil {
 		return err
 	}
-	idx := NewIndex(indexRW)
-	err = idx.Load()
+	idx, err := NewIndex(indexRW)
 	if err != nil {
 		return err
 	}

--- a/datalog_test.go
+++ b/datalog_test.go
@@ -126,7 +126,10 @@ func BenchmarkRebuildIndex(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		idx := NewIndex(idxF)
+		idx, err := NewIndex(idxF)
+		if err != nil {
+			b.Fatal(err)
+		}
 		dl.index = idx
 		// isolated test
 		b.ResetTimer()

--- a/index_test.go
+++ b/index_test.go
@@ -20,8 +20,9 @@ func TestIndex(t *testing.T) {
 	var index []byte
 
 	t.Run("write", func(t *testing.T) {
-		var idxRW bytes.Buffer
-		idx := NewIndex(&idxRW)
+		idxRW := bytes.NewBuffer([]byte{})
+		idx, err := NewIndex(idxRW)
+		assert.NoError(err)
 		for pos, word := range strings.Fields(words) {
 			data := []byte(word)
 			size := len(data)
@@ -38,12 +39,11 @@ func TestIndex(t *testing.T) {
 		copy(index, idxRW.Bytes())
 	})
 
-	t.Run("load", func(t *testing.T) {
+	t.Run("open", func(t *testing.T) {
 		tmp := make([]byte, len(index))
 		copy(tmp, index)
 		idxRW := bytes.NewBuffer(tmp)
-		idx := NewIndex(idxRW)
-		err = idx.Load()
+		idx, err := NewIndex(idxRW)
 		assert.NoError(err)
 		assert.Len(idx.cache, len(strings.Fields(words)))
 	})
@@ -52,8 +52,7 @@ func TestIndex(t *testing.T) {
 		tmp := make([]byte, len(index))
 		copy(tmp, index)
 		idxRW := bytes.NewBuffer(tmp)
-		idx := NewIndex(idxRW)
-		err = idx.Load()
+		idx, err := NewIndex(idxRW)
 		assert.NoError(err)
 		for pos, word := range strings.Fields(words) {
 			data := []byte(word)
@@ -77,7 +76,7 @@ func TestIndex(t *testing.T) {
 }
 
 // BenchmarkIndexLoad for iterative improvement of open
-func BenchmarkIndexLoad(b *testing.B) {
+func BenchmarkIndexOpen(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
 		f, err := os.Open("testdata/words.idx")
@@ -85,8 +84,7 @@ func BenchmarkIndexLoad(b *testing.B) {
 			b.Fatal(err)
 		}
 		b.StartTimer()
-		idx := NewIndex(f)
-		err = idx.Load()
+		_, err = NewIndex(f)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
## No big impact:

```
benchmark                   old ns/op      new ns/op      delta
BenchmarkRebuildIndex-4     3058643446     2980298658     -2.56%
BenchmarkIndexLoad-4        80980738       81759976       +0.96%

benchmark                   old allocs     new allocs     delta
BenchmarkRebuildIndex-4     245708         245600         -0.04%
BenchmarkIndexLoad-4        10976          11005          +0.26%

benchmark                   old bytes     new bytes     delta
BenchmarkRebuildIndex-4     48646032      48623864      -0.05%
BenchmarkIndexLoad-4        46753343      46764222      +0.02%
```