### PR TITLE
Use bufio in index

### DIFF
--- a/datalog.go
+++ b/datalog.go
@@ -7,6 +7,10 @@ import (
 	"os"
 )
 
+const (
+	intSize = 4
+)
+
 // Datalogger is the interface for Datalog
 type Datalogger interface {
 	Open() error


### PR DESCRIPTION
Not terrible

```
benchmark                   old ns/op      new ns/op      delta
BenchmarkRebuildIndex-4     3057378563     3149105318     +3.00%
BenchmarkIndexOpen-4        84033624       88828879       +5.71%
BenchmarkOpen-4             85151476       84580846       -0.67%
BenchmarkWrite-4            25907          27113          +4.66%
BenchmarkRead-4             3987           4054           +1.68%

benchmark                   old allocs     new allocs     delta
BenchmarkRebuildIndex-4     245601         245622         +0.01%
BenchmarkIndexOpen-4        10948          9591           -12.39%
BenchmarkOpen-4             11022          9619           -12.73%
BenchmarkWrite-4            2              2              +0.00%
BenchmarkRead-4             1              1              +0.00%

benchmark                   old bytes     new bytes     delta
BenchmarkRebuildIndex-4     48632536      48633608      +0.00%
BenchmarkIndexOpen-4        46740594      41069390      -12.13%
BenchmarkOpen-4             46763651      41074774      -12.17%
BenchmarkWrite-4            1291          1292          +0.08%
BenchmarkRead-4             16            16            +0.00%
```

Side-note: using `binary.Read/3` and `binary.Write/3` surprisingly(?) gives perf penalty, so not switching to them.