### PR TITLE
Refactor io management

### DIFF
--- a/api.go
+++ b/api.go
@@ -11,7 +11,7 @@ import (
 // Store represents a data store.
 type Store struct {
 	name string
-	data Datalogger
+	data *Datalog
 	irw  *os.File
 }
 

--- a/datalog.go
+++ b/datalog.go
@@ -11,18 +11,10 @@ const (
 	intSize = 4
 )
 
-// Datalogger is the interface for Datalog
-type Datalogger interface {
-	Open() error
-	Read(score Score) (data []byte, err error)
-	Write(data []byte) (score Score, err error)
-	Close() error
-}
-
 // Datalog represents a datalog file
 type Datalog struct {
 	name  string
-	index Indexer
+	index *Index
 	cur   int
 	rwc   *os.File
 }

--- a/datalog_test.go
+++ b/datalog_test.go
@@ -64,7 +64,7 @@ func TestDataLog(t *testing.T) {
 		err = dl.Open()
 		assert.NoError(err)
 		defer dl.Close()
-		stat, err := dl.rwc.Stat()
+		stat, err := dl.writer.Stat()
 		assert.NoError(err)
 		end := int(stat.Size())
 		assert.EqualValues(end, dl.cur, "Cursor should be at EOF")
@@ -84,7 +84,7 @@ func TestDataLog(t *testing.T) {
 		err = dl.Open()
 		assert.NoError(err)
 		defer dl.Close()
-		stat, err := dl.rwc.Stat()
+		stat, err := dl.writer.Stat()
 		assert.NoError(err)
 		end := int(stat.Size())
 		assert.EqualValues(end, dl.cur, "Cursor should be at EOF")
@@ -104,7 +104,7 @@ func TestDataLog(t *testing.T) {
 		err = dl.Open()
 		assert.NoError(err)
 		defer dl.Close()
-		stat, err := dl.rwc.Stat()
+		stat, err := dl.writer.Stat()
 		assert.NoError(err)
 		end := int(stat.Size())
 		assert.Equal(end, dl.cur, "Cursor should be at EOF")
@@ -123,15 +123,15 @@ func TestDataLog(t *testing.T) {
 func BenchmarkRebuildIndex(b *testing.B) {
 	// open data file
 	name := "testdata/words"
-	f, err := os.Open(name + ".data")
+	reader, err := os.Open(name + ".data")
 	if err != nil {
 		b.Fatal(err)
 	}
-	stat, err := f.Stat()
+	stat, err := reader.Stat()
 	if err != nil {
 		b.Fatal(err)
 	}
-	dl := &Datalog{name: name, cur: int(stat.Size()), rwc: f}
+	dl := &Datalog{name: name, cur: int(stat.Size()), reader: reader}
 	for n := 0; n < b.N; n++ {
 		// create an empty index and set it to datalog
 		idxName := RandomName()

--- a/index.go
+++ b/index.go
@@ -12,13 +12,6 @@ const (
 	pageSize  = 4080 // 4096 - (4096 mod 24)
 )
 
-// Indexer is the interface for Datalog's index
-type Indexer interface {
-	Read(score Score) (Addr, bool)
-	Write(score Score, a Addr) error
-	Len() int
-}
-
 // Addr is data position and size in datalog
 type Addr struct {
 	pos  int

--- a/index_test.go
+++ b/index_test.go
@@ -12,9 +12,6 @@ import (
 // TestIndex for compliance to Indexer
 func TestIndex(t *testing.T) {
 	assert := require.New(t)
-	name := RandomName()
-	err := CreateDatalogFile(name)
-	assert.NoError(err)
 
 	words := "The quick brown fox jumps over the lazy dog"
 	var index []byte
@@ -76,10 +73,6 @@ func TestIndex(t *testing.T) {
 		assert.Empty(a.size, "Should return 0 size for missing score")
 		assert.False(ok, "Should indicate that score doesn't exists")
 	})
-
-	// cleanup
-	err = removeDatalogFile(name)
-	assert.NoError(err)
 }
 
 // BenchmarkIndexOpen for iterative improvement of open

--- a/index_test.go
+++ b/index_test.go
@@ -23,7 +23,9 @@ func TestIndex(t *testing.T) {
 		idxRW := bytes.NewBuffer([]byte{})
 		idx, err := NewIndex(idxRW)
 		assert.NoError(err)
-		for pos, word := range strings.Fields(words) {
+		assert.Equal(0, idx.Cur())
+		pos := 0
+		for _, word := range strings.Fields(words) {
 			data := []byte(word)
 			size := len(data)
 			score := MakeScore(data)
@@ -31,6 +33,7 @@ func TestIndex(t *testing.T) {
 			err := idx.Write(score, Addr{pos: pos, size: size})
 			assert.NoError(err)
 			assert.Equal(expAddr, idx.cache[score])
+			pos += size
 			err = idx.Write(score, Addr{pos: 0, size: 0})
 			assert.NoError(err)
 			assert.Equal(expAddr, idx.cache[score], "Should ignore update")
@@ -46,6 +49,7 @@ func TestIndex(t *testing.T) {
 		idx, err := NewIndex(idxRW)
 		assert.NoError(err)
 		assert.Len(idx.cache, len(strings.Fields(words)))
+		assert.Equal(35, idx.Cur())
 	})
 
 	t.Run("read", func(t *testing.T) {
@@ -54,7 +58,9 @@ func TestIndex(t *testing.T) {
 		idxRW := bytes.NewBuffer(tmp)
 		idx, err := NewIndex(idxRW)
 		assert.NoError(err)
-		for pos, word := range strings.Fields(words) {
+		assert.Equal(35, idx.Cur())
+		pos := 0
+		for _, word := range strings.Fields(words) {
 			data := []byte(word)
 			size := len(data)
 			score := MakeScore(data)
@@ -62,6 +68,7 @@ func TestIndex(t *testing.T) {
 			assert.Equal(pos, a.pos, "Should return correct position")
 			assert.Equal(size, a.size, "Should return correct size")
 			assert.True(ok, "Should indicate that score exists")
+			pos += size
 		}
 		score := MakeScore([]byte("missing"))
 		a, ok := idx.Read(score)


### PR DESCRIPTION
Make datalog and index to work with `io.Reader` and `io.Writer`, move file management to `api` module (prepare to make it cli), move datalog cursor management to index, speed up index rebuild a bit.