### PR TITLE
Switch from md5 to xxhash for score

### DIFF
--- a/score.go
+++ b/score.go
@@ -1,12 +1,14 @@
 package dieci
 
 import (
-	"crypto/md5"
+	"encoding/binary"
 	"encoding/hex"
+
+	"github.com/cespare/xxhash"
 )
 
 // scoreSize is the size of score in bytes
-const scoreSize = 16
+const scoreSize = 8
 
 // Score is type alias for score representation
 type Score [scoreSize]byte
@@ -17,6 +19,8 @@ func (s Score) String() string {
 
 // MakeScore creates a score for a given data block
 func MakeScore(b []byte) Score {
-	score := md5.Sum(b)
+	sum := xxhash.Sum64(b)
+	score := Score{}
+	binary.BigEndian.PutUint64(score[:], sum)
 	return score
 }

--- a/score_test.go
+++ b/score_test.go
@@ -11,6 +11,6 @@ import (
 func TestScoreMakeScore(t *testing.T) {
 	data := []byte("brown fox")
 	score := MakeScore(data)
-	expect := "fdd929ffb0a167ab33e8b1a8905858cf"
+	expect := "7113fd84e8973eb2"
 	assert.Equal(t, expect, fmt.Sprintf("%s", score))
 }


### PR DESCRIPTION
Bench:

```
benchmark                   old ns/op      new ns/op      delta
BenchmarkOpenIndex-4        82574461       65227740       -21.01%
BenchmarkRebuildIndex-4     1379846122     1370667311     -0.67%
BenchmarkOpen-4             81791544       65762731       -19.60%
BenchmarkWrite-4            22247          19775          -11.11%
BenchmarkRead-4             1965           1661           -15.47%

benchmark                   old allocs     new allocs     delta
BenchmarkOpenIndex-4        9616           9666           +0.52%
BenchmarkRebuildIndex-4     245445         245524         +0.03%
BenchmarkOpen-4             9616           9693           +0.80%
BenchmarkWrite-4            2              2              +0.00%
BenchmarkRead-4             1              1              +0.00%

benchmark                   old bytes     new bytes     delta
BenchmarkOpenIndex-4        41077400      31396703      -23.57%
BenchmarkRebuildIndex-4     48616296      38929176      -19.93%
BenchmarkOpen-4             41072258      31403386      -23.54%
BenchmarkWrite-4            1292          1266          -2.01%
BenchmarkRead-4             32            32            +0.00%
```