### PR TITLE
Remove index persistency

### DIFF
--- a/datalog.go
+++ b/datalog.go
@@ -48,9 +48,7 @@ func (d *Datalog) Write(data []byte) (Score, error) {
 	if err != nil {
 		return Score{}, err
 	}
-	if err = d.index.Write(score, size); err != nil {
-		return Score{}, err
-	}
+	d.index.Write(score, size)
 	return score, nil
 }
 

--- a/datalog_test.go
+++ b/datalog_test.go
@@ -2,7 +2,6 @@ package dieci
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,66 +11,68 @@ import (
 func TestDataLog(t *testing.T) {
 	assert := require.New(t)
 
-	words := "The quick brown fox jumps over the lazy dog"
+	var datalogtests = []struct {
+		in   string
+		size int
+	}{
+		{"the", 15},
+		{"quick", 32},
+		{"brown", 49},
+		{"fox", 64},
+		{"jumps", 81},
+		{"over", 97},
+		{"the", 97},
+		{"lazy", 113},
+		{"dog", 128},
+	}
+
 	var datalog []byte
 	var index []byte
 
 	t.Run("write", func(t *testing.T) {
-		dw := bytes.NewBuffer([]byte{})
 		dr := bytes.NewReader([]byte{})
+		dw := bytes.NewBuffer([]byte{})
 		irw := bytes.NewBuffer([]byte{})
 		idx, err := NewIndex(irw)
 		assert.NoError(err)
 		dl := NewDatalog(dr, dw, idx)
-
-		for _, word := range strings.Fields(words) {
-			data := []byte(word)
+		for _, tt := range datalogtests {
+			data := []byte(tt.in)
 			expectedScore := MakeScore(data)
 			score, err := dl.Write(data)
 			assert.NoError(err)
 			assert.Equal(expectedScore, score)
+			assert.Len(dw.Bytes(), tt.size)
 		}
-
 		datalog = make([]byte, dw.Len())
 		copy(datalog, dw.Bytes())
 		index = make([]byte, irw.Len())
 		copy(index, irw.Bytes())
 	})
 
+	t.Run("rebuild index", func(t *testing.T) {
+		dr := bytes.NewReader(datalog)
+		irw := bytes.NewBuffer([]byte{})
+		idx, err := NewIndex(irw)
+		assert.NoError(err)
+		err = idx.Rebuild(dr)
+		assert.NoError(err)
+		assert.Equal(index, irw.Bytes())
+	})
+
 	t.Run("read", func(t *testing.T) {
-		tmp := make([]byte, len(datalog))
-		copy(tmp, datalog)
+		dr := bytes.NewReader(datalog)
 		dw := bytes.NewBuffer([]byte{})
-		dr := bytes.NewReader(tmp)
-		tmp = make([]byte, len(index))
-		copy(tmp, index)
-		irw := bytes.NewBuffer(tmp)
+		irw := bytes.NewBuffer(index)
 		idx, err := NewIndex(irw)
 		assert.NoError(err)
 		dl := NewDatalog(dr, dw, idx)
-
-		for _, word := range strings.Fields(words) {
-			expectedData := []byte(word)
+		for _, tt := range datalogtests {
+			expectedData := []byte(tt.in)
 			score := MakeScore(expectedData)
 			data, err := dl.Read(score)
 			assert.NoError(err)
 			assert.Equal(expectedData, data)
-		}
-	})
-
-	t.Run("rebuild index", func(t *testing.T) {
-		irw := bytes.NewBuffer([]byte{})
-		idx, err := NewIndex(irw)
-		assert.NoError(err)
-
-		dr := bytes.NewReader(datalog)
-		err = idx.Rebuild(dr)
-		assert.NoError(err)
-
-		for _, word := range strings.Fields(words) {
-			score := MakeScore([]byte(word))
-			_, ok := idx.Read(score)
-			assert.True(ok)
 		}
 	})
 }

--- a/datalog_test.go
+++ b/datalog_test.go
@@ -27,13 +27,11 @@ func TestDataLog(t *testing.T) {
 	}
 
 	var datalog []byte
-	var index []byte
 
 	t.Run("write", func(t *testing.T) {
 		dr := bytes.NewReader([]byte{})
 		dw := bytes.NewBuffer([]byte{})
-		irw := bytes.NewBuffer([]byte{})
-		idx, err := NewIndex(irw)
+		idx, err := NewIndex(dr)
 		assert.NoError(err)
 		dl := NewDatalog(dr, dw, idx)
 		for _, tt := range datalogtests {
@@ -46,25 +44,12 @@ func TestDataLog(t *testing.T) {
 		}
 		datalog = make([]byte, dw.Len())
 		copy(datalog, dw.Bytes())
-		index = make([]byte, irw.Len())
-		copy(index, irw.Bytes())
-	})
-
-	t.Run("rebuild index", func(t *testing.T) {
-		dr := bytes.NewReader(datalog)
-		irw := bytes.NewBuffer([]byte{})
-		idx, err := NewIndex(irw)
-		assert.NoError(err)
-		err = idx.Rebuild(dr)
-		assert.NoError(err)
-		assert.Equal(index, irw.Bytes())
 	})
 
 	t.Run("read", func(t *testing.T) {
 		dr := bytes.NewReader(datalog)
 		dw := bytes.NewBuffer([]byte{})
-		irw := bytes.NewBuffer(index)
-		idx, err := NewIndex(irw)
+		idx, err := NewIndex(dr)
 		assert.NoError(err)
 		dl := NewDatalog(dr, dw, idx)
 		for _, tt := range datalogtests {

--- a/index.go
+++ b/index.go
@@ -3,7 +3,6 @@ package dieci
 import (
 	"bufio"
 	"encoding/binary"
-	"fmt"
 	"io"
 )
 
@@ -24,34 +23,12 @@ type cache map[Score]Addr
 type Index struct {
 	cache cache
 	cur   int
-	rw    io.ReadWriter
 }
 
 // NewIndex returns a new index structure with the given name
-func NewIndex(rw io.ReadWriter) (*Index, error) {
+func NewIndex(reader io.Reader) (*Index, error) {
 	cache := make(cache)
-	idx := &Index{cache: cache, rw: rw}
-	scanner := bufio.NewScanner(rw)
-	scanner.Split(func(data []byte, eof bool) (int, []byte, error) {
-		if eof && len(data) == 0 {
-			return 0, nil, io.EOF
-		}
-		return blockSize, data, nil
-	})
-	for scanner.Scan() {
-		block := scanner.Bytes()
-		score, addr := idx.Decode(block)
-		cache[score] = addr
-		idx.cur = addr.pos + addr.size
-	}
-	if scanner.Err() != nil {
-		return nil, scanner.Err()
-	}
-	return idx, nil
-}
-
-// Rebuild index by scaning given datalog reader
-func (idx *Index) Rebuild(reader io.Reader) error {
+	idx := &Index{cache: cache}
 	scanner := bufio.NewScanner(reader)
 	blockSize := intSize + scoreSize
 	scanner.Split(func(data []byte, eof bool) (int, []byte, error) {
@@ -68,21 +45,17 @@ func (idx *Index) Rebuild(reader io.Reader) error {
 		return advance, data[:blockSize], nil
 	})
 
-	var err error
 	for scanner.Scan() {
 		block := scanner.Bytes()
 		size := int(binary.BigEndian.Uint32(block[:intSize]))
 		var score Score
 		copy(score[:], block[intSize:])
-		err = idx.Write(score, size+4)
-		if err != nil {
-			break
-		}
+		idx.Write(score, size+4)
 	}
-	if err == nil {
-		err = scanner.Err()
+	if scanner.Err() != nil {
+		return &Index{}, scanner.Err()
 	}
-	return err
+	return idx, nil
 }
 
 // Read reads address of data for a given score
@@ -92,36 +65,12 @@ func (idx *Index) Read(score Score) (a Addr, ok bool) {
 }
 
 // Write writes given score into index file and adds it to the cache
-func (idx *Index) Write(score Score, size int) error {
-	if _, ok := idx.cache[score]; ok {
-		return nil
+func (idx *Index) Write(score Score, size int) {
+	if _, ok := idx.cache[score]; !ok {
+		addr := Addr{pos: idx.cur, size: size}
+		idx.cache[score] = addr
+		idx.cur = addr.pos + addr.size
 	}
-	addr := Addr{pos: idx.cur, size: size}
-	idx.cache[score] = addr
-	idx.cur = addr.pos + addr.size
-	buf := idx.Encode(score, addr)
-	if _, err := idx.rw.Write(buf); err != nil {
-		return fmt.Errorf("index: write failed: %s", err)
-	}
-	return nil
-}
-
-// Decode serialized bytes to score and addess
-func (idx *Index) Decode(block []byte) (score Score, addr Addr) {
-	copy(score[:], block[:])
-	pos := binary.BigEndian.Uint32(block[scoreSize:])
-	size := binary.BigEndian.Uint32(block[scoreSize+4:])
-	addr = Addr{pos: int(pos), size: int(size)}
-	return score, addr
-}
-
-// Encode serialize map entry into slice of bytes suitable to write on disk
-func (idx *Index) Encode(score Score, addr Addr) []byte {
-	buf := make([]byte, blockSize)
-	copy(buf[:], score[:])
-	binary.BigEndian.PutUint32(buf[scoreSize:], uint32(addr.pos))
-	binary.BigEndian.PutUint32(buf[scoreSize+4:], uint32(addr.size))
-	return buf
 }
 
 // Len returns current length of cache

--- a/index.go
+++ b/index.go
@@ -74,7 +74,7 @@ func (idx *Index) Rebuild(reader io.Reader) error {
 		size := int(binary.BigEndian.Uint32(block[:intSize]))
 		var score Score
 		copy(score[:], block[intSize:])
-		err = idx.Write(score, size)
+		err = idx.Write(score, size+4)
 		if err != nil {
 			break
 		}

--- a/index_test.go
+++ b/index_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,65 +13,77 @@ import (
 func TestIndex(t *testing.T) {
 	assert := require.New(t)
 
-	words := "The quick brown fox jumps over the lazy dog"
+	var idxtests = []struct {
+		in   string
+		addr Addr
+		ok   bool
+	}{
+		{"the", Addr{pos: 0, size: 3}, true},
+		{"quick", Addr{pos: 3, size: 5}, true},
+		{"brown", Addr{pos: 8, size: 5}, true},
+		{"fox", Addr{pos: 13, size: 3}, true},
+		{"jumps", Addr{pos: 16, size: 5}, true},
+		{"over", Addr{pos: 21, size: 4}, true},
+		{"missing", Addr{pos: 0, size: 0}, false},
+		{"the", Addr{pos: 0, size: 3}, true},
+		{"lazy", Addr{pos: 25, size: 4}, true},
+		{"dog", Addr{pos: 29, size: 3}, true},
+	}
+
 	var index []byte
 
-	t.Run("write", func(t *testing.T) {
-		idxRW := bytes.NewBuffer([]byte{})
-		idx, err := NewIndex(idxRW)
+	t.Run("open empty", func(t *testing.T) {
+		rw := bytes.NewBuffer([]byte{})
+		idx, err := NewIndex(rw)
 		assert.NoError(err)
+		assert.Len(idx.cache, 0)
 		assert.Equal(0, idx.cur)
-		pos := 0
-		for _, word := range strings.Fields(words) {
-			data := []byte(word)
+	})
+
+	t.Run("write", func(t *testing.T) {
+		rw := bytes.NewBuffer([]byte{})
+		idx, err := NewIndex(rw)
+		assert.NoError(err)
+		for _, tt := range idxtests {
+			if !tt.ok {
+				continue
+			}
+			data := []byte(tt.in)
 			size := len(data)
 			score := MakeScore(data)
-			expAddr := Addr{pos, size}
 			err := idx.Write(score, size)
 			assert.NoError(err)
-			assert.Equal(expAddr, idx.cache[score])
-			pos += size
+			before := idx.Len()
 			err = idx.Write(score, 0)
 			assert.NoError(err)
-			assert.Equal(expAddr, idx.cache[score], "Should ignore update")
+			assert.Equal(before, idx.Len(), "Should ignore same update")
 		}
-		index = make([]byte, idxRW.Len())
-		copy(index, idxRW.Bytes())
+		index = make([]byte, rw.Len())
+		copy(index, rw.Bytes())
 	})
 
 	t.Run("open", func(t *testing.T) {
-		tmp := make([]byte, len(index))
-		copy(tmp, index)
-		idxRW := bytes.NewBuffer(tmp)
-		idx, err := NewIndex(idxRW)
+		rw := bytes.NewBuffer(index)
+		idx, err := NewIndex(rw)
 		assert.NoError(err)
-		assert.Len(idx.cache, len(strings.Fields(words)))
-		assert.Equal(35, idx.cur)
+		assert.Len(idx.cache, 8)
+		assert.Equal(32, idx.cur)
 	})
 
 	t.Run("read", func(t *testing.T) {
-		tmp := make([]byte, len(index))
-		copy(tmp, index)
-		idxRW := bytes.NewBuffer(tmp)
-		idx, err := NewIndex(idxRW)
+		rw := bytes.NewBuffer(index)
+		idx, err := NewIndex(rw)
 		assert.NoError(err)
-		assert.Equal(35, idx.cur)
-		pos := 0
-		for _, word := range strings.Fields(words) {
-			data := []byte(word)
-			size := len(data)
-			score := MakeScore(data)
-			a, ok := idx.Read(score)
-			assert.Equal(pos, a.pos, "Should return correct position")
-			assert.Equal(size, a.size, "Should return correct size")
-			assert.True(ok, "Should indicate that score exists")
-			pos += size
+		for _, tt := range idxtests {
+			score := MakeScore([]byte(tt.in))
+			addr, ok := idx.Read(score)
+			if tt.ok {
+				assert.True(ok, "Should indicate that score exists")
+			} else {
+				assert.False(ok, "Should indicate that score is missing")
+			}
+			assert.Equal(tt.addr, addr, "Should return correct address")
 		}
-		score := MakeScore([]byte("missing"))
-		a, ok := idx.Read(score)
-		assert.Empty(a.pos, "Should return 0 position for missing score")
-		assert.Empty(a.size, "Should return 0 size for missing score")
-		assert.False(ok, "Should indicate that score doesn't exists")
 	})
 }
 


### PR DESCRIPTION
Convert tests into table driven and remove index persistency, coz +10% ns/op on open worth -40% decrease on write

```
$ benchcmp before.bench after.bench 
benchmark                   old ns/op      new ns/op     delta
BenchmarkOpenIndex-4        59921526       65754714      +9.73%
BenchmarkRebuildIndex-4     1151763798     64047897      -94.44%
BenchmarkOpen-4             59038646       64539848      +9.32%
BenchmarkWrite-4            20064          11718         -41.60%
BenchmarkRead-4             1696           1696          +0.00%

benchmark                   old allocs     new allocs     delta
BenchmarkOpenIndex-4        9672           9681           +0.09%
BenchmarkRebuildIndex-4     245483         9682           -96.06%
BenchmarkOpen-4             9676           9687           +0.11%
BenchmarkWrite-4            2              1              -50.00%
BenchmarkRead-4             1              1              +0.00%

benchmark                   old bytes     new bytes     delta
BenchmarkOpenIndex-4        31398202      31401925      +0.01%
BenchmarkRebuildIndex-4     35164512      31402700      -10.70%
BenchmarkOpen-4             31400805      31400878      +0.00%
BenchmarkWrite-4            1250          1234          -1.28%
BenchmarkRead-4             32            32            +0.00%
```