### PR TITLE
Convert score from byte array to uint64

### DIFF
--- a/datalog.go
+++ b/datalog.go
@@ -70,14 +70,13 @@ func (dl *Datalog) Serialize(score Score, data []byte) []byte {
 	size := scoreSize + len(data)
 	buf := make([]byte, intSize+size)
 	binary.BigEndian.PutUint32(buf, uint32(size))
-	copy(buf[intSize:], score[:])
+	binary.BigEndian.PutUint64(buf[intSize:], uint64(score))
 	copy(buf[intSize+scoreSize:], data)
 	return buf
 }
 
 // Deserialize read block to score and its data
 func (dl *Datalog) Deserialize(data []byte) (Score, []byte) {
-	score := Score{}
-	copy(score[:], data[intSize:])
-	return score, data[intSize+scoreSize:]
+	sum := binary.BigEndian.Uint64(data[intSize:])
+	return Score(sum), data[intSize+scoreSize:]
 }

--- a/datalog_test.go
+++ b/datalog_test.go
@@ -68,7 +68,7 @@ func TestDataLog(t *testing.T) {
 		dw := bytes.NewBuffer([]byte{})
 		dl := NewDatalog(dr, dw)
 		for _, tt := range datalogtests {
-			score := Score{}
+			var score Score
 			data := []byte(tt.in)
 			serialized := dl.Serialize(score, data)
 			assert.NotEqual(data, serialized)

--- a/dieci.go
+++ b/dieci.go
@@ -70,7 +70,7 @@ func (s *Store) Write(data []byte) (Score, error) {
 	}
 	size, err := s.data.Write(data)
 	if err != nil {
-		return Score{}, err
+		return score, err
 	}
 	s.index.Put(score, size)
 	return score, nil

--- a/index.go
+++ b/index.go
@@ -55,9 +55,8 @@ func (idx *Index) Load(reader io.Reader) error {
 	for scanner.Scan() {
 		block := scanner.Bytes()
 		size := int(binary.BigEndian.Uint32(block[:intSize]))
-		var score Score
-		copy(score[:], block[intSize:])
-		idx.Put(score, size+4)
+		sum := binary.BigEndian.Uint64(block[intSize:])
+		idx.Put(Score(sum), size+intSize)
 	}
 	if scanner.Err() != nil {
 		return scanner.Err()

--- a/score.go
+++ b/score.go
@@ -1,8 +1,7 @@
 package dieci
 
 import (
-	"encoding/binary"
-	"encoding/hex"
+	"strconv"
 
 	"github.com/OneOfOne/xxhash"
 )
@@ -11,16 +10,15 @@ import (
 const scoreSize = 8
 
 // Score is type alias for score representation
-type Score [scoreSize]byte
+// type Score [scoreSize]byte
+type Score uint64
 
 func (s Score) String() string {
-	return hex.EncodeToString(s[:])
+	return strconv.FormatInt(int64(s), 16)
 }
 
 // MakeScore creates a score for a given data block
 func MakeScore(b []byte) Score {
 	sum := xxhash.Checksum64(b)
-	score := Score{}
-	binary.BigEndian.PutUint64(score[:], sum)
-	return score
+	return Score(sum)
 }


### PR DESCRIPTION
Don't confuse representation with serialization 😉 

```
$ benchcmp before.bench after.bench
benchmark                old ns/op     new ns/op     delta
BenchmarkOpenIndex-4     85194920      72041524      -15.44%
BenchmarkOpen-4          61195548      60705285      -0.80%
BenchmarkWrite-4         12458         12381         -0.62%
BenchmarkRead-4          1148          1120          -2.44%

benchmark                old allocs     new allocs     delta
BenchmarkOpenIndex-4     9680           9696           +0.17%
BenchmarkOpen-4          9654           9665           +0.11%
BenchmarkWrite-4         1              1              +0.00%
BenchmarkRead-4          1              1              +0.00%

benchmark                old bytes     new bytes     delta
BenchmarkOpenIndex-4     31402293      31406146      +0.01%
BenchmarkOpen-4          31392038      31396432      +0.01%
BenchmarkWrite-4         1246          1247          +0.08%
BenchmarkRead-4          32            32            +0.00%
```